### PR TITLE
Add GitLab compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,13 +33,15 @@ Syntax:
     $ oca-port <source> <target> <module_path> [options]
     $ oca-port --help
 
-GITHUB_TOKEN can be passed by exposing to environment:
+GITHUB_TOKEN (or GITLAB_TOKEN when using GitLab) can be passed by exposing to
+environment:
 
     $ export GITHUB_TOKEN=<token>
 
 Alternatively, you can pass the token directly using the `--github-token` option
 
 If neither method is used, the tool will attempt to obtain the token using the `gh` client (if it's installed).
+Use `--platform gitlab` to work with GitLab repositories.
 
 To check if an addon could be migrated or to get eligible commits to port:
 

--- a/oca_port/app.py
+++ b/oca_port/app.py
@@ -12,6 +12,7 @@ from .migrate_addon import MigrateAddon
 from .port_addon_pr import PortAddonPullRequest
 from .utils.git import Branch
 from .utils.github import GitHub
+from .utils.gitlab import GitLab
 from .utils.misc import Output, bcolors as bc, extract_ref_info
 
 
@@ -55,8 +56,11 @@ class App(Output):
         clear_cache:
             flag to remove the user's cache once the process is done
         github_token:
-            Token to use when requesting GitHub API (highly recommended
+            Token to use when requesting the platform API (highly recommended
             to not trigger the "API rate limit exceeded" error).
+        platform:
+            Git hosting platform to use. Supported values are 'github' and
+            'gitlab'.
     """
 
     source: str
@@ -76,6 +80,7 @@ class App(Output):
     no_cache: bool = False
     clear_cache: bool = False
     github_token: str = None
+    platform: str = "github"
     cli: bool = False  # Not documented, should not be used outside of the CLI
 
     _available_outputs = ("json",)
@@ -107,8 +112,16 @@ class App(Output):
         # Check if source & target branches exist
         self._check_branch_exists(self.source.ref, raise_exc=True)
         self._check_branch_exists(self.target.ref, raise_exc=True)
-        # GitHub API helper
-        self.github = GitHub(self.github_token)
+        # API helper depending on the platform
+        platform = (
+            self.platform or self.source.get("platform") or self.target.get("platform")
+        )
+        if platform and platform.lower() == "gitlab":
+            self.github = GitLab(self.github_token)
+            self.platform = "gitlab"
+        else:
+            self.github = GitHub(self.github_token)
+            self.platform = "github"
         # Initialize storage & cache
         self.storage = utils.storage.InputStorage(self.to_branch, self.addon)
         self.cache = utils.cache.UserCacheFactory(self).build()

--- a/oca_port/cli/main.py
+++ b/oca_port/cli/main.py
@@ -101,8 +101,15 @@ from ..utils.misc import bcolors as bc
 @click.option(
     "--github-token",
     is_flag=True,
-    help="""Token to use when requesting GitHub API (highly recommended
-            to not trigger the "API rate limit exceeded" error).""",
+    help="""Token to use when requesting API (highly recommended
+            to not trigger the 'API rate limit exceeded' error).""",
+)
+@click.option(
+    "--platform",
+    type=click.Choice(["github", "gitlab"]),
+    default="github",
+    show_default=True,
+    help="Git hosting platform",
 )
 def main(
     addon_path: str,
@@ -121,6 +128,7 @@ def main(
     clear_cache: bool,
     dry_run: bool,
     github_token: str,
+    platform: str,
 ):
     """Migrate ADDON from SOURCE to TARGET or list Pull Requests to port.
 
@@ -156,6 +164,7 @@ def main(
             dry_run=dry_run,
             cli=True,
             github_token=github_token,
+            platform=platform,
         )
     except ForkValueError as exc:
         error_msg = prepare_remote_error_msg(*exc.args)

--- a/oca_port/tests/common.py
+++ b/oca_port/tests/common.py
@@ -36,14 +36,18 @@ class CommonCase(unittest.TestCase):
         # By cloning the first repository this will set an 'origin' remote
         self.repo_path = self._clone_tmp_git_repository(self.repo_upstream_path)
         self._add_fork_remote(self.repo_path)
-        # Patch GitHub class to prevent sending HTTP requests
-        self._patch_github_class()
+        # Patch API classes to prevent sending HTTP requests
+        self._patch_api_classes()
 
-    def _patch_github_class(self):
+    def _patch_api_classes(self):
         self.patcher = patch("oca_port.app.GitHub.request")
         github_request = self.patcher.start()
         github_request.return_value = {}
         self.addCleanup(self.patcher.stop)
+        self.patcher_gl = patch("oca_port.app.GitLab.request")
+        gitlab_request = self.patcher_gl.start()
+        gitlab_request.return_value = {}
+        self.addCleanup(self.patcher_gl.stop)
 
     def _create_tmp_git_repository(self):
         """Create a temporary Git repository to run tests."""

--- a/oca_port/tests/test_app.py
+++ b/oca_port/tests/test_app.py
@@ -104,6 +104,12 @@ class TestApp(common.CommonCase):
         with self.assertRaisesRegex(ValueError, error_msg):
             app.run()
 
+    def test_app_gitlab_platform(self):
+        app = self._create_app(self.source1, self.target1, platform="gitlab")
+        from oca_port.utils.gitlab import GitLab
+
+        self.assertIsInstance(app.github, GitLab)
+
     def test_app_nothing_to_port_non_interactive(self):
         app = self._create_app(self.source1, self.target1, non_interactive=True)
         result = app.run()

--- a/oca_port/tests/test_utils_gitlab.py
+++ b/oca_port/tests/test_utils_gitlab.py
@@ -1,0 +1,18 @@
+import unittest
+
+from oca_port.utils import gitlab
+
+
+class TestGitLab(unittest.TestCase):
+    def setUp(self):
+        super().setUp()
+        self.gl = gitlab.GitLab(token="test")
+
+    def test_token(self):
+        assert self.gl.token == "test"
+
+    def test_addon_in_text(self):
+        res = self.gl._addon_in_text("a_b", "[16.0][MIG] a_b: migration to 16.0")
+        assert res
+        res = self.gl._addon_in_text("a_b", "[16.0][MIG] a_b_c: migration to 16.0")
+        assert not res

--- a/oca_port/utils/gitlab.py
+++ b/oca_port/utils/gitlab.py
@@ -1,0 +1,84 @@
+import os
+import re
+import subprocess
+import urllib.parse
+
+import requests
+
+from .git import PullRequest
+
+GITLAB_API_URL = "https://gitlab.com/api/v4"
+
+
+class GitLab:
+    def __init__(self, token=None):
+        if not token:
+            token = self._get_token()
+        self.token = token
+
+    def request(self, url: str, method: str = "get", params=None, json=None):
+        """Request GitLab API."""
+        headers = {}
+        if self.token:
+            headers["Private-Token"] = self.token
+        full_url = "/".join([GITLAB_API_URL, url])
+        response = getattr(requests, method)(
+            full_url, headers=headers, params=params, json=json
+        )
+        if not response.ok:
+            raise RuntimeError(response.text)
+        return response.json()
+
+    def get_original_pr(
+        self, from_org: str, repo_name: str, branch: str, commit_sha: str
+    ):
+        """Return original GitLab MR data of a commit."""
+        project = urllib.parse.quote(f"{from_org}/{repo_name}", safe="")
+        mrs = self.request(
+            f"projects/{project}/repository/commits/{commit_sha}/merge_requests"
+        )
+        for mr in mrs:
+            if mr.get("target_branch") == branch:
+                return mr
+        return {}
+
+    def search_migration_pr(
+        self, from_org: str, repo_name: str, branch: str, addon: str
+    ):
+        """Return an existing migration MR (if any) of `addon` for `branch`."""
+        project = urllib.parse.quote(f"{from_org}/{repo_name}", safe="")
+        for state in ("opened", "merged"):
+            mrs = self.request(
+                f"projects/{project}/merge_requests",
+                params={
+                    "state": state,
+                    "target_branch": branch,
+                    "search": addon,
+                    "in": "title",
+                },
+            )
+            for mr in mrs:
+                if self._addon_in_text(addon, mr["title"]):
+                    return PullRequest(
+                        number=mr["iid"],
+                        url=mr["web_url"],
+                        author=mr.get("author", {}).get("username", ""),
+                        title=mr["title"],
+                        body=mr.get("description", ""),
+                    )
+
+    def _addon_in_text(self, addon: str, text: str):
+        """Return ``True`` if ``addon`` is present in ``text``."""
+        return any(addon == term for term in re.split(r"\W+", text))
+
+    @staticmethod
+    def _get_token():
+        token = os.environ.get("GITLAB_TOKEN")
+        if not token:
+            try:
+                token = subprocess.check_output(
+                    ["glab", "auth", "token"], text=True
+                ).strip()
+            except (subprocess.SubprocessError, FileNotFoundError):
+                pass
+        return token


### PR DESCRIPTION
## Summary
- implement `GitLab` API helper
- switch API helper depending on `--platform`
- allow selecting platform from CLI
- update tests for new platform
- document GitLab support in README

## Testing
- `pre-commit run --files README.md oca_port/app.py oca_port/cli/main.py oca_port/tests/common.py oca_port/tests/test_app.py oca_port/tests/test_utils_gitlab.py oca_port/utils/gitlab.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b1e2571a08324b60d4800b17d4c44